### PR TITLE
fix: handle unknown entity types during response unmarshalling

### DIFF
--- a/patreon/api/unmarshal_response.go
+++ b/patreon/api/unmarshal_response.go
@@ -48,7 +48,12 @@ func UnmarshalEntity(entityData json.RawMessage) (any, error) {
 		target = t
 		break
 	default:
-		return nil, fmt.Errorf("unknown entity type: %s", unmarshalStruct.Type)
+		t := map[string]any{}
+		err = json.Unmarshal(entityData, &t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal unknown entity type '%s': %w", unmarshalStruct.Type, err)
+		}
+		target = t
 	}
 
 	if err != nil {

--- a/patreon/api/unmarshal_response_test.go
+++ b/patreon/api/unmarshal_response_test.go
@@ -384,10 +384,18 @@ var entity = struct {
 }
 
 func TestUnmarshalEntity(t *testing.T) {
-	t.Run("fails if unknown entity type is given", func(t *testing.T) {
-		entityBytes := []byte(`{"type": "unknown"}`)
-		_, err := UnmarshalEntity(entityBytes)
-		assert.ErrorContains(t, err, "unknown entity type")
+	t.Run("unmarshalls unknown entities into maps", func(t *testing.T) {
+		entityBytes := []byte(`{"type": "unknown", "id": "unknown-id", "attributes": {"key": "value"}}`)
+		unmarshalled, err := UnmarshalEntity(entityBytes)
+		require.NoError(t, err)
+
+		expected := map[string]any{
+			"type":       "unknown",
+			"id":         "unknown-id",
+			"attributes": map[string]any{"key": "value"},
+		}
+
+		assert.Equal(t, expected, unmarshalled)
 	})
 
 	t.Run("fails if entity bytes are not valid JSON", func(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where unmarshalling a response which included a unknown entity type would panic. Unknown entities are now unmarshlled into a `map[string]any`